### PR TITLE
fix: protect callbacks against failures

### DIFF
--- a/Casbin.Watcher.Redis/Casbin.Watcher.Redis.csproj
+++ b/Casbin.Watcher.Redis/Casbin.Watcher.Redis.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Casbin.NET" Version="2.1.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.17" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.1" Condition="'$(TargetFramework)'=='netstandard2.1'" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Casbin.Watcher.Redis/RedisWatcher.cs
+++ b/Casbin.Watcher.Redis/RedisWatcher.cs
@@ -148,14 +148,18 @@ public class RedisWatcher : IWatcher
             var isSelf = message.Id == Id;
             if (!(isSelf && _options.IgnoreSelf))
             {
-                if (_callbackWithMessage != null)
+                try
                 {
-                    _callbackWithMessage.Invoke(message);
+                    if (_callbackWithMessage != null)
+                    {
+                        _callbackWithMessage.Invoke(message);
+                    }
+                    else
+                    {
+                        _callback?.Invoke();
+                    }
                 }
-                else
-                {
-                    _callback?.Invoke();
-                }
+                catch {}
             }
         });
     }
@@ -170,14 +174,18 @@ public class RedisWatcher : IWatcher
             var isSelf = message.Id == Id;
             if (!(isSelf && _options.IgnoreSelf))
             {
-                if (_asyncCallbackWithMessage != null)
+                try
                 {
-                    _asyncCallbackWithMessage.Invoke(message);
+                    if (_asyncCallbackWithMessage != null)
+                    {
+                        _asyncCallbackWithMessage.Invoke(message);
+                    }
+                    else
+                    {
+                        _asyncCallback?.Invoke();
+                    }
                 }
-                else
-                {
-                    _asyncCallback?.Invoke();
-                }
+                catch {}
             }
         });
     }


### PR DESCRIPTION
If the callback throws the watcher will stop responding